### PR TITLE
miflora lib updated to version 0.3

### DIFF
--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -13,6 +13,7 @@ from colorama import Fore, Back, Style
 from configparser import ConfigParser
 from unidecode import unidecode
 from miflora.miflora_poller import MiFloraPoller, MI_BATTERY, MI_CONDUCTIVITY, MI_LIGHT, MI_MOISTURE, MI_TEMPERATURE
+from miflora.backends.gatttool import GatttoolBackend
 import paho.mqtt.client as mqtt
 import sdnotify
 
@@ -205,7 +206,7 @@ for [name, mac] in config['Sensors'].items():
     print('Name:          "{}"'.format(name_pretty))
     #print_line('Attempting initial connection to Mi Flora sensor "{}" ({})'.format(name_pretty, mac), console=False, sd_notify=True)
 
-    flora_poller = MiFloraPoller(mac=mac, cache_timeout=miflora_cache_timeout, retries=3, adapter=used_adapter)
+    flora_poller = MiFloraPoller(mac=mac, backend=GatttoolBackend, cache_timeout=miflora_cache_timeout, retries=3, adapter=used_adapter)
     flora['poller'] = flora_poller
     flora['name_pretty'] = name_pretty
     flora['mac'] = flora_poller._mac

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 #git+https://github.com/open-homeautomation/miflora.git#egg=miflora
-miflora==0.1.16
+miflora==0.3
 paho-mqtt==1.3.0
 wheel==0.29.0
 sdnotify==0.3.1


### PR DESCRIPTION
miflora lib updated to version 0.3 to support negative temperature values. See https://github.com/open-homeautomation/miflora/pull/65 for more information.

Used miflora constructor changed and it is using the `GatttoolBackend`. This is not a configurable option.

Requirements file changed accordingly.