### PR TITLE
Docker images for arm32v6, arm32v7 and arm64v8

### DIFF
--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -39,7 +39,7 @@ RUN set -ex \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
     && rm -rf /tmp/* \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
     && adduser -D -u 1000 miflora \
     && chgrp -Rf root /opt/miflora-mqtt-daemon \
     && chmod -Rf g+w /opt/miflora-mqtt-daemon \

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -11,7 +11,7 @@ ARG QEMU_ARCH
 LABEL org.label-schema.build-date=${BUILD_DATE} \
     org.label-schema.docker.dockerfile=".docker/Dockerfile.alpine-tmpl" \
     org.label-schema.license="GNU" \
-    org.label-schema.name="Emqtt" \
+    org.label-schema.name="miflora-mqtt" \
     org.label-schema.version=${BUILD_VERSION} \
     org.label-schema.description="Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon" \
     org.label-schema.url="https://github.com/ThomDietrich/miflora-mqtt-daemon" \
@@ -26,8 +26,9 @@ COPY tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
 COPY ./requirements.txt /tmp/requirements.txt
 COPY ./miflora-mqtt-daemon.py /tmp/miflora-mqtt-daemon.py
 COPY ./config.ini.dist /tmp/config.ini.dist
+COPY ./start.sh /tmp/start.sh
 
-# Install required packages
+# Install required packages 
 RUN set -ex \
     && apk add --no-cache --virtual .run-deps \
         bluez \
@@ -35,7 +36,7 @@ RUN set -ex \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && mkdir -p /opt/miflora-mqtt-daemon/config \
     && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
-    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config \
+    && mv /tmp/start.sh /opt/miflora-mqtt-daemon \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
     && rm -rf /tmp/* \
@@ -47,8 +48,8 @@ RUN set -ex \
 
 WORKDIR /opt/miflora-mqtt-daemon
 
-# start miflora-mqtt-daemon
-CMD [ "python3", "./miflora-mqtt-daemon.py", "--config_dir", "/opt/miflora-mqtt-daemon/config" ]
+# Start miflora-mqtt-daemon
+CMD [".start.sh"]
 
 USER miflora
 

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -37,6 +37,7 @@ RUN set -ex \
     && mkdir -p /opt/miflora-mqtt-daemon/config \
     && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
     && mv /tmp/start.sh /opt/miflora-mqtt-daemon \
+    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config.ini.dist \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && chmod +x /opt/miflora-mqtt-daemon/start.sh \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -40,7 +40,7 @@ RUN set -ex \
     && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
-    && rm -rf /tmp/*
+    && rm -rf /tmp/* \
     && rm -rf /var/cache/apk/*
 
 WORKDIR /opt/miflora-mqtt-daemon

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -37,7 +37,7 @@ RUN set -ex \
     && mkdir -p /opt/miflora-mqtt-daemon/config \
     && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
     && mv /tmp/start.sh /opt/miflora-mqtt-daemon \
-    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config.ini.dist \
+    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini.dist \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && chmod +x /opt/miflora-mqtt-daemon/start.sh \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -29,10 +29,8 @@ COPY ./config.ini.dist /tmp/config.ini.dist
 
 # Install required packages
 RUN set -ex \
-    # add run deps, never remove
     && apk add --no-cache --virtual .run-deps \
         bluez \
-
     && pip install --upgrade pip \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && mkdir -p /opt/miflora-mqtt-daemon/config \
@@ -42,16 +40,15 @@ RUN set -ex \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
     && rm -rf /tmp/* \
     && rm -rf /var/cache/apk/*
+    && adduser -D -u 1000 miflora \
+    && chgrp -Rf root /opt/miflora-mqtt-daemon \
+    && chmod -Rf g+w /opt/miflora-mqtt-daemon \
+    && chown -Rf miflora /opt/miflora-mqtt-daemon
 
 WORKDIR /opt/miflora-mqtt-daemon
 
 # start miflora-mqtt-daemon
 CMD [ "python3", "./miflora-mqtt-daemon.py", "--config_dir", "/opt/miflora-mqtt-daemon/config" ]
-
-RUN adduser -D -u 1000 miflora
-
-RUN chgrp -Rf root /opt/miflora-mqtt-daemon && chmod -Rf g+w /opt/miflora-mqtt-daemon \
-      && chown -Rf miflora /opt/miflora-mqtt-daemon
 
 USER miflora
 

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -38,6 +38,7 @@ RUN set -ex \
     && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
     && mv /tmp/start.sh /opt/miflora-mqtt-daemon \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
+    && chmod +x /opt/miflora-mqtt-daemon/start.sh \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
     && rm -rf /tmp/* \
     && rm -rf /var/cache/apk/* \
@@ -49,7 +50,7 @@ RUN set -ex \
 WORKDIR /opt/miflora-mqtt-daemon
 
 # Start miflora-mqtt-daemon
-CMD ["./start.sh"]
+CMD ["/opt/miflora-mqtt-daemon/start.sh"]
 
 USER miflora
 

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -1,0 +1,54 @@
+ARG BUILD_FROM
+FROM ${BUILD_FROM}
+
+# Build arguments
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REF
+ARG QEMU_ARCH
+
+# Basic build-time metadata as defined at http://label-schema.org
+LABEL org.label-schema.build-date=${BUILD_DATE} \
+    org.label-schema.docker.dockerfile=".docker/Dockerfile.alpine-tmpl" \
+    org.label-schema.license="GNU" \
+    org.label-schema.name="Emqtt" \
+    org.label-schema.version=${BUILD_VERSION} \
+    org.label-schema.description="Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon" \
+    org.label-schema.url="https://github.com/ThomDietrich/miflora-mqtt-daemon" \
+    org.label-schema.vcs-ref=${BUILD_REF} \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.vcs-url="https://github.com/ThomDietrich/miflora-mqtt-daemon" \
+    maintainer="Raymond M Mouthaan <raymondmmouthaan@gmail.com>"
+
+USER root
+COPY tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
+
+COPY ./requirements.txt /requirements.txt
+COPY ./miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon
+COPY ./config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini
+
+# Install required packages
+RUN set -ex \
+    # add run deps, never remove
+    && apk add --no-cache --virtual .run-deps \
+        bluez \
+
+    && pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
+    && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
+    && rm -rf /var/cache/apk/*
+
+WORKDIR /opt/miflora-mqtt-daemon
+
+# start miflora-mqtt-daemon
+CMD [ "python3", "./miflora-mqtt-daemon.py", "--config_dir", "/opt/miflora-mqtt-daemon/config" ]
+
+RUN adduser -D -u 1000 miflora
+
+RUN chgrp -Rf root /opt/miflora-mqtt-daemon && chmod -Rf g+w /opt/miflora-mqtt-daemon \
+      && chown -Rf miflora /opt/miflora-mqtt-daemon
+
+USER miflora
+
+VOLUME ["/opt/miflora-mqtt-daemon/config"]

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -23,9 +23,9 @@ LABEL org.label-schema.build-date=${BUILD_DATE} \
 USER root
 COPY tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
 
-COPY ./requirements.txt /requirements.txt
-COPY ./miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon
-COPY ./config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini
+COPY ./requirements.txt /tmp/requirements.txt
+COPY ./miflora-mqtt-daemon.py /tmp/miflora-mqtt-daemon.py
+COPY ./config.ini.dist /tmp/config.ini.dist
 
 # Install required packages
 RUN set -ex \
@@ -34,9 +34,13 @@ RUN set -ex \
         bluez \
 
     && pip install --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && mkdir -p /opt/miflora-mqtt-daemon/config \
+    && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
+    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
+    && rm -rf /tmp/*
     && rm -rf /var/cache/apk/*
 
 WORKDIR /opt/miflora-mqtt-daemon

--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -28,7 +28,7 @@ COPY ./miflora-mqtt-daemon.py /tmp/miflora-mqtt-daemon.py
 COPY ./config.ini.dist /tmp/config.ini.dist
 COPY ./start.sh /tmp/start.sh
 
-# Install required packages 
+# Install required packages
 RUN set -ex \
     && apk add --no-cache --virtual .run-deps \
         bluez \
@@ -49,7 +49,7 @@ RUN set -ex \
 WORKDIR /opt/miflora-mqtt-daemon
 
 # Start miflora-mqtt-daemon
-CMD [".start.sh"]
+CMD ["./start.sh"]
 
 USER miflora
 

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -1,0 +1,136 @@
+ARG BUILD_FROM
+FROM ${BUILD_FROM}
+
+# Build arguments
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REF
+ARG QEMU_ARCH
+
+# Basic build-time metadata as defined at http://label-schema.org
+LABEL org.label-schema.build-date=${BUILD_DATE} \
+    org.label-schema.docker.dockerfile=".docker/Dockerfile.alpine-tmpl" \
+    org.label-schema.license="GNU" \
+    org.label-schema.name="Emqtt" \
+    org.label-schema.version=${BUILD_VERSION} \
+    org.label-schema.description="The Massively Scalable MQTT Broker for IoT and Mobile Applications" \
+    org.label-schema.url="http://emqtt.io/" \
+    org.label-schema.vcs-ref=${BUILD_REF} \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.vcs-url="https://github.com/RaymondMouthaan/emqtt-docker" \
+    maintainer="Raymond M Mouthaan <raymondmmouthaan@gmail.com>"
+
+USER root
+COPY tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
+
+COPY ./start.sh /start.sh
+
+# Install required packages
+RUN set -ex \
+    # add build deps, remove after build
+    && apk --no-cache add --virtual .build-deps \
+        build-base \
+        # gcc \
+        # make \
+        bsd-compat-headers \
+        perl \
+        erlang \
+        erlang-public-key \
+        erlang-syntax-tools \
+        erlang-erl-docgen \
+        #erlang-gs \
+        erlang-observer \
+        erlang-ssh \
+        #erlang-ose \
+        erlang-cosfiletransfer \
+        erlang-runtime-tools \
+        erlang-os-mon \
+        erlang-tools \
+        erlang-cosproperty \
+        erlang-common-test \
+        erlang-dialyzer \
+        erlang-edoc \
+        erlang-otp-mibs \
+        erlang-crypto \
+        erlang-costransaction \
+        erlang-odbc \
+        erlang-inets \
+        erlang-asn1 \
+        erlang-snmp \
+        erlang-erts \
+        erlang-et \
+        erlang-cosnotification \
+        erlang-xmerl \
+        #erlang-typer \
+        erlang-coseventdomain \
+        erlang-stdlib \
+        erlang-diameter \
+        erlang-hipe \
+        erlang-ic \
+        erlang-eunit \
+        #erlang-webtool \
+        erlang-mnesia \
+        erlang-erl-interface \
+        #erlang-test-server \
+        erlang-sasl \
+        erlang-jinterface \
+        erlang-kernel \
+        erlang-orber \
+        erlang-costime \
+        #erlang-percept \
+        erlang-dev \
+        erlang-eldap \
+        erlang-reltool \
+        erlang-debugger \
+        erlang-ssl \
+        erlang-megaco \
+        erlang-parsetools \
+        erlang-cosevent \
+        erlang-compiler \
+    # add fetch deps, remove after build
+    && apk add --no-cache --virtual .fetch-deps \
+        git \
+        wget \
+    # add run deps, never remove
+    && apk add --no-cache --virtual .run-deps \
+        ncurses-terminfo-base \
+        ncurses-terminfo \
+        ncurses-libs \
+        readline \
+    # add latest rebar
+    && git clone -b ${BUILD_VERSION} https://github.com/emqtt/emq-relx.git /emqttd \
+    && cd /emqttd \
+    && make \
+    && mkdir -p /opt && mv /emqttd/_rel/emqttd /opt/emqttd \
+    && cd / && rm -rf /emqttd \
+    && mv /start.sh /opt/emqttd/start.sh \
+    && chmod +x /opt/emqttd/start.sh \
+    && ln -s /opt/emqttd/bin/* /usr/local/bin/ \
+    # removing fetch deps and build deps
+    && apk --purge del .build-deps .fetch-deps \
+    && rm -rf /var/cache/apk/*
+
+WORKDIR /opt/emqttd
+
+# start emqttd and initial environments
+CMD ["/opt/emqttd/start.sh"]
+
+RUN adduser -D -u 1000 emqtt
+
+RUN chgrp -Rf root /opt/emqttd && chmod -Rf g+w /opt/emqttd \
+      && chown -Rf emqtt /opt/emqttd
+
+USER emqtt
+
+VOLUME ["/opt/emqttd/log", "/opt/emqttd/data", "/opt/emqttd/lib", "/opt/emqttd/etc"]
+
+# emqttd will occupy these port:
+# - 1883 port for MQTT
+# - 8883 port for MQTT(SSL)
+# - 8083 for WebSocket/HTTP
+# - 8084 for WSS/HTTPS
+# - 8080 for mgmt API
+# - 18083 for dashboard
+# - 4369 for port mapping
+# - 6000-6999 for distributed node
+EXPOSE 1883 8883 8083 8084 8080 18083 4369 6000-6999

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -49,7 +49,7 @@ RUN set -ex \
 WORKDIR /opt/miflora-mqtt-daemon
 
 # Start miflora-mqtt-daemon
-CMD [".start.sh"]
+CMD ["./start.sh"]
 
 USER miflora
 

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -38,6 +38,7 @@ RUN set -ex \
     && mkdir -p /opt/miflora-mqtt-daemon/config \
     && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
     && mv /tmp/start.sh /opt/miflora-mqtt-daemon \
+    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config.ini.dist \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && chmod +x /opt/miflora-mqtt-daemon/start.sh \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -39,16 +39,15 @@ RUN set -ex \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
     && rm -rf /tmp/* \
+    && adduser --disabled-password -u 1000 miflora \
+    && chgrp -Rf root /opt/miflora-mqtt-daemon \
+    && chmod -Rf g+w /opt/miflora-mqtt-daemon \
+    && chown -Rf miflora /opt/miflora-mqtt-daemon
 
 WORKDIR /opt/miflora-mqtt-daemon
 
 # start miflora-mqtt-daemon
 CMD [ "python3", "./miflora-mqtt-daemon.py", "--config_dir", "/opt/miflora-mqtt-daemon/config" ]
-
-RUN adduser -D -u 1000 miflora
-
-RUN chgrp -Rf root /opt/miflora-mqtt-daemon && chmod -Rf g+w /opt/miflora-mqtt-daemon \
-      && chown -Rf miflora /opt/miflora-mqtt-daemon
 
 USER miflora
 

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -30,7 +30,8 @@ COPY ./config.ini.dist /tmp/config.ini.dist
 # Install required packages
 RUN set -ex \
     && apt-get update \
-    && apt-get install -y bluez \
+    && apt-get install -y \
+        bluez \
     && pip install --upgrade pip \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && mkdir -p /opt/miflora-mqtt-daemon/config \

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -13,124 +13,43 @@ LABEL org.label-schema.build-date=${BUILD_DATE} \
     org.label-schema.license="GNU" \
     org.label-schema.name="Emqtt" \
     org.label-schema.version=${BUILD_VERSION} \
-    org.label-schema.description="The Massively Scalable MQTT Broker for IoT and Mobile Applications" \
-    org.label-schema.url="http://emqtt.io/" \
+    org.label-schema.description="Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon" \
+    org.label-schema.url="https://github.com/ThomDietrich/miflora-mqtt-daemon" \
     org.label-schema.vcs-ref=${BUILD_REF} \
     org.label-schema.vcs-type="Git" \
-    org.label-schema.vcs-url="https://github.com/RaymondMouthaan/emqtt-docker" \
+    org.label-schema.vcs-url="https://github.com/ThomDietrich/miflora-mqtt-daemon" \
     maintainer="Raymond M Mouthaan <raymondmmouthaan@gmail.com>"
 
 USER root
 COPY tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
 
-COPY ./start.sh /start.sh
+COPY ./requirements.txt /tmp/requirements.txt
+COPY ./miflora-mqtt-daemon.py /tmp/miflora-mqtt-daemon.py
+COPY ./config.ini.dist /tmp/config.ini.dist
 
 # Install required packages
 RUN set -ex \
-    # add build deps, remove after build
-    && apk --no-cache add --virtual .build-deps \
-        build-base \
-        # gcc \
-        # make \
-        bsd-compat-headers \
-        perl \
-        erlang \
-        erlang-public-key \
-        erlang-syntax-tools \
-        erlang-erl-docgen \
-        #erlang-gs \
-        erlang-observer \
-        erlang-ssh \
-        #erlang-ose \
-        erlang-cosfiletransfer \
-        erlang-runtime-tools \
-        erlang-os-mon \
-        erlang-tools \
-        erlang-cosproperty \
-        erlang-common-test \
-        erlang-dialyzer \
-        erlang-edoc \
-        erlang-otp-mibs \
-        erlang-crypto \
-        erlang-costransaction \
-        erlang-odbc \
-        erlang-inets \
-        erlang-asn1 \
-        erlang-snmp \
-        erlang-erts \
-        erlang-et \
-        erlang-cosnotification \
-        erlang-xmerl \
-        #erlang-typer \
-        erlang-coseventdomain \
-        erlang-stdlib \
-        erlang-diameter \
-        erlang-hipe \
-        erlang-ic \
-        erlang-eunit \
-        #erlang-webtool \
-        erlang-mnesia \
-        erlang-erl-interface \
-        #erlang-test-server \
-        erlang-sasl \
-        erlang-jinterface \
-        erlang-kernel \
-        erlang-orber \
-        erlang-costime \
-        #erlang-percept \
-        erlang-dev \
-        erlang-eldap \
-        erlang-reltool \
-        erlang-debugger \
-        erlang-ssl \
-        erlang-megaco \
-        erlang-parsetools \
-        erlang-cosevent \
-        erlang-compiler \
-    # add fetch deps, remove after build
-    && apk add --no-cache --virtual .fetch-deps \
-        git \
-        wget \
-    # add run deps, never remove
-    && apk add --no-cache --virtual .run-deps \
-        ncurses-terminfo-base \
-        ncurses-terminfo \
-        ncurses-libs \
-        readline \
-    # add latest rebar
-    && git clone -b ${BUILD_VERSION} https://github.com/emqtt/emq-relx.git /emqttd \
-    && cd /emqttd \
-    && make \
-    && mkdir -p /opt && mv /emqttd/_rel/emqttd /opt/emqttd \
-    && cd / && rm -rf /emqttd \
-    && mv /start.sh /opt/emqttd/start.sh \
-    && chmod +x /opt/emqttd/start.sh \
-    && ln -s /opt/emqttd/bin/* /usr/local/bin/ \
-    # removing fetch deps and build deps
-    && apk --purge del .build-deps .fetch-deps \
-    && rm -rf /var/cache/apk/*
+    && apt-get update \
+    && apt-get install -y bluez \
+    && pip install --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && mkdir -p /opt/miflora-mqtt-daemon/config \
+    && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
+    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config \
+    && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
+    && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
+    && rm -rf /tmp/* \
 
-WORKDIR /opt/emqttd
+WORKDIR /opt/miflora-mqtt-daemon
 
-# start emqttd and initial environments
-CMD ["/opt/emqttd/start.sh"]
+# start miflora-mqtt-daemon
+CMD [ "python3", "./miflora-mqtt-daemon.py", "--config_dir", "/opt/miflora-mqtt-daemon/config" ]
 
-RUN adduser -D -u 1000 emqtt
+RUN adduser -D -u 1000 miflora
 
-RUN chgrp -Rf root /opt/emqttd && chmod -Rf g+w /opt/emqttd \
-      && chown -Rf emqtt /opt/emqttd
+RUN chgrp -Rf root /opt/miflora-mqtt-daemon && chmod -Rf g+w /opt/miflora-mqtt-daemon \
+      && chown -Rf miflora /opt/miflora-mqtt-daemon
 
-USER emqtt
+USER miflora
 
-VOLUME ["/opt/emqttd/log", "/opt/emqttd/data", "/opt/emqttd/lib", "/opt/emqttd/etc"]
-
-# emqttd will occupy these port:
-# - 1883 port for MQTT
-# - 8883 port for MQTT(SSL)
-# - 8083 for WebSocket/HTTP
-# - 8084 for WSS/HTTPS
-# - 8080 for mgmt API
-# - 18083 for dashboard
-# - 4369 for port mapping
-# - 6000-6999 for distributed node
-EXPOSE 1883 8883 8083 8084 8080 18083 4369 6000-6999
+VOLUME ["/opt/miflora-mqtt-daemon/config"]

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -38,7 +38,7 @@ RUN set -ex \
     && mkdir -p /opt/miflora-mqtt-daemon/config \
     && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
     && mv /tmp/start.sh /opt/miflora-mqtt-daemon \
-    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config.ini.dist \
+    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini.dist \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && chmod +x /opt/miflora-mqtt-daemon/start.sh \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -9,9 +9,9 @@ ARG QEMU_ARCH
 
 # Basic build-time metadata as defined at http://label-schema.org
 LABEL org.label-schema.build-date=${BUILD_DATE} \
-    org.label-schema.docker.dockerfile=".docker/Dockerfile.alpine-tmpl" \
+    org.label-schema.docker.dockerfile=".docker/Dockerfile.slim-tmpl" \
     org.label-schema.license="GNU" \
-    org.label-schema.name="Emqtt" \
+    org.label-schema.name="miflora-mqtt" \
     org.label-schema.version=${BUILD_VERSION} \
     org.label-schema.description="Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon" \
     org.label-schema.url="https://github.com/ThomDietrich/miflora-mqtt-daemon" \
@@ -26,6 +26,7 @@ COPY tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
 COPY ./requirements.txt /tmp/requirements.txt
 COPY ./miflora-mqtt-daemon.py /tmp/miflora-mqtt-daemon.py
 COPY ./config.ini.dist /tmp/config.ini.dist
+COPY ./start.sh /tmp/start.sh
 
 # Install required packages
 RUN set -ex \
@@ -36,7 +37,7 @@ RUN set -ex \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && mkdir -p /opt/miflora-mqtt-daemon/config \
     && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
-    && mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config \
+    && mv /tmp/start.sh /opt/miflora-mqtt-daemon \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
     && rm -rf /tmp/* \
@@ -47,8 +48,8 @@ RUN set -ex \
 
 WORKDIR /opt/miflora-mqtt-daemon
 
-# start miflora-mqtt-daemon
-CMD [ "python3", "./miflora-mqtt-daemon.py", "--config_dir", "/opt/miflora-mqtt-daemon/config" ]
+# Start miflora-mqtt-daemon
+CMD [".start.sh"]
 
 USER miflora
 

--- a/.docker/Dockerfile.slim-tmpl
+++ b/.docker/Dockerfile.slim-tmpl
@@ -39,6 +39,7 @@ RUN set -ex \
     && mv /tmp/miflora-mqtt-daemon.py /opt/miflora-mqtt-daemon \
     && mv /tmp/start.sh /opt/miflora-mqtt-daemon \
     && chmod +x /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py \
+    && chmod +x /opt/miflora-mqtt-daemon/start.sh \
     && ln -s /opt/miflora-mqtt-daemon/* /usr/local/bin/ \
     && rm -rf /tmp/* \
     && adduser --disabled-password -u 1000 miflora \
@@ -49,7 +50,7 @@ RUN set -ex \
 WORKDIR /opt/miflora-mqtt-daemon
 
 # Start miflora-mqtt-daemon
-CMD ["./start.sh"]
+CMD ["/opt/miflora-mqtt-daemon/start.sh"]
 
 USER miflora
 

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -86,13 +86,13 @@ docker_manifest_list_version() {
   # Manifest Create BUILD_VERSION
   echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}."
   docker manifest create ${TARGET}:${BUILD_VERSION} \
-      ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-      ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-      ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+      #${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+      #${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
 
   # Manifest Annotate BUILD_VERSION
-  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+  #docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm32 --variant=v6
 
   # Manifest Push BUILD_VERSION
   docker manifest push ${TARGET}:${BUILD_VERSION}
@@ -102,48 +102,48 @@ docker_manifest_list_latest() {
   # Manifest Create latest
   echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:latest."
   docker manifest create ${TARGET}:latest \
-      ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-      ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-      ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+      # ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+      # ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
 
   # Manifest Annotate BUILD_VERSION
-  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+  # docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm32 --variant=v6
 
   # Manifest Push BUILD_VERSION
   docker manifest push ${TARGET}:latest
 }
 
 docker_manifest_list_version_os_arch() {
-  # Manifest Create alpine-amd64
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-amd64."
-  docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-      ${TARGET}:${BUILD_VERSION}-alpine-amd64
+  # # Manifest Create alpine-amd64
+  # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-amd64."
+  # docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+  #     ${TARGET}:${BUILD_VERSION}-alpine-amd64
+  #
+  # # Manifest Push alpine-amd64
+  # docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-amd64
+  #
+  # # Manifest Create slim-arm32v7
+  # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-slim-arm32v7."
+  # docker manifest create ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+  #     ${TARGET}:${BUILD_VERSION}-slim-arm32v7
+  #
+  # # Manifest Annotate slim-arm32v7
+  # docker manifest annotate ${TARGET}:${BUILD_VERSION}-slim-arm32v7 ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+  #
+  # # Manifest Push slim-arm32v7
+  # docker manifest push ${TARGET}:${BUILD_VERSION}-slim-arm32v7
 
-  # Manifest Push alpine-amd64
-  docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-amd64
-
-  # Manifest Create slim-arm32v7
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-slim-arm32v7."
-  docker manifest create ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-      ${TARGET}:${BUILD_VERSION}-slim-arm32v7
-
-  # Manifest Annotate slim-arm32v7
-  docker manifest annotate ${TARGET}:${BUILD_VERSION}-slim-arm32v7 ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-
-  # Manifest Push slim-arm32v7
-  docker manifest push ${TARGET}:${BUILD_VERSION}-slim-arm32v7
-
-  # Manifest Create alpine-arm64v8
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-arm64v8."
-  docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 \
-      ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
-
-  # Manifest Annotate alpine-arm64v8
-  docker manifest annotate ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
-
-  # Manifest Push alpine-amd64
-  docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+  # # Manifest Create alpine-arm64v8
+  # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-arm64v8."
+  # docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 \
+  #     ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+  #
+  # # Manifest Annotate alpine-arm64v8
+  # docker manifest annotate ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+  #
+  # # Manifest Push alpine-amd64
+  # docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
 }
 
 setup_dependencies() {
@@ -185,9 +185,9 @@ prepare_qemu(){
     docker run --rm --privileged multiarch/qemu-user-static:register --reset
     mkdir tmp
     pushd tmp &&
-    curl -L -o qemu-x86_64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-x86_64-static.tar.gz && tar xzf qemu-x86_64-static.tar.gz &&
+    #curl -L -o qemu-x86_64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-x86_64-static.tar.gz && tar xzf qemu-x86_64-static.tar.gz &&
     curl -L -o qemu-arm-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-arm-static.tar.gz && tar xzf qemu-arm-static.tar.gz &&
-    curl -L -o qemu-aarch64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-aarch64-static.tar.gz && tar xzf qemu-aarch64-static.tar.gz &&
+    #curl -L -o qemu-aarch64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-aarch64-static.tar.gz && tar xzf qemu-aarch64-static.tar.gz &&
     popd
 }
 

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -187,7 +187,7 @@ prepare_qemu(){
     pushd tmp &&
     #curl -L -o qemu-x86_64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-x86_64-static.tar.gz && tar xzf qemu-x86_64-static.tar.gz &&
     curl -L -o qemu-arm-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-arm-static.tar.gz && tar xzf qemu-arm-static.tar.gz &&
-    #curl -L -o qemu-aarch64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-aarch64-static.tar.gz && tar xzf qemu-aarch64-static.tar.gz &&
+    curl -L -o qemu-aarch64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-aarch64-static.tar.gz && tar xzf qemu-aarch64-static.tar.gz &&
     popd
 }
 

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -74,77 +74,77 @@ docker_push() {
     docker push ${TARGET}:${BUILD_VERSION}-${OS_ARCH}
 }
 
-docker_manifest_list() {
-    # Create and push manifest lists, displayed as FIFO
-    echo "DOCKER MANIFEST: Create and Push docker manifest lists."
-    docker_manifest_list_version
-    docker_manifest_list_latest
-    docker_manifest_list_version_os_arch
-}
-
-docker_manifest_list_version() {
-  # Manifest Create BUILD_VERSION
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}."
-  docker manifest create ${TARGET}:${BUILD_VERSION} \
-      #${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-      #${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-      ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
-
-  # Manifest Annotate BUILD_VERSION
-  #docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm32 --variant=v6
-
-  # Manifest Push BUILD_VERSION
-  docker manifest push ${TARGET}:${BUILD_VERSION}
-}
-
-docker_manifest_list_latest() {
-  # Manifest Create latest
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:latest."
-  docker manifest create ${TARGET}:latest \
-      # ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-      # ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-      ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
-
-  # Manifest Annotate BUILD_VERSION
-  # docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm32 --variant=v6
-
-  # Manifest Push BUILD_VERSION
-  docker manifest push ${TARGET}:latest
-}
-
-docker_manifest_list_version_os_arch() {
-  # # Manifest Create alpine-amd64
-  # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-amd64."
-  # docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-  #     ${TARGET}:${BUILD_VERSION}-alpine-amd64
-  #
-  # # Manifest Push alpine-amd64
-  # docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-amd64
-  #
-  # # Manifest Create slim-arm32v7
-  # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-slim-arm32v7."
-  # docker manifest create ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-  #     ${TARGET}:${BUILD_VERSION}-slim-arm32v7
-  #
-  # # Manifest Annotate slim-arm32v7
-  # docker manifest annotate ${TARGET}:${BUILD_VERSION}-slim-arm32v7 ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-  #
-  # # Manifest Push slim-arm32v7
-  # docker manifest push ${TARGET}:${BUILD_VERSION}-slim-arm32v7
-
-  # # Manifest Create alpine-arm64v8
-  # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-arm64v8."
-  # docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 \
-  #     ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
-  #
-  # # Manifest Annotate alpine-arm64v8
-  # docker manifest annotate ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
-  #
-  # # Manifest Push alpine-amd64
-  # docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
-}
+# docker_manifest_list() {
+#     # Create and push manifest lists, displayed as FIFO
+#     echo "DOCKER MANIFEST: Create and Push docker manifest lists."
+#     docker_manifest_list_version
+#     docker_manifest_list_latest
+#     docker_manifest_list_version_os_arch
+# }
+#
+# docker_manifest_list_version() {
+#   # Manifest Create BUILD_VERSION
+#   echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}."
+#   docker manifest create ${TARGET}:${BUILD_VERSION} \
+#       #${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+#       #${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+#       ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
+#
+#   # Manifest Annotate BUILD_VERSION
+#   #docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+#   docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm32 --variant=v6
+#
+#   # Manifest Push BUILD_VERSION
+#   docker manifest push ${TARGET}:${BUILD_VERSION}
+# }
+#
+# docker_manifest_list_latest() {
+#   # Manifest Create latest
+#   echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:latest."
+#   docker manifest create ${TARGET}:latest \
+#       # ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+#       # ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+#       ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
+#
+#   # Manifest Annotate BUILD_VERSION
+#   # docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+#   docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm32 --variant=v6
+#
+#   # Manifest Push BUILD_VERSION
+#   docker manifest push ${TARGET}:latest
+# }
+#
+# docker_manifest_list_version_os_arch() {
+#   # # Manifest Create alpine-amd64
+#   # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-amd64."
+#   # docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+#   #     ${TARGET}:${BUILD_VERSION}-alpine-amd64
+#   #
+#   # # Manifest Push alpine-amd64
+#   # docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-amd64
+#   #
+#   # # Manifest Create slim-arm32v7
+#   # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-slim-arm32v7."
+#   # docker manifest create ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+#   #     ${TARGET}:${BUILD_VERSION}-slim-arm32v7
+#   #
+#   # # Manifest Annotate slim-arm32v7
+#   # docker manifest annotate ${TARGET}:${BUILD_VERSION}-slim-arm32v7 ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+#   #
+#   # # Manifest Push slim-arm32v7
+#   # docker manifest push ${TARGET}:${BUILD_VERSION}-slim-arm32v7
+#
+#   # # Manifest Create alpine-arm64v8
+#   # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-arm64v8."
+#   # docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 \
+#   #     ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+#   #
+#   # # Manifest Annotate alpine-arm64v8
+#   # docker manifest annotate ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+#   #
+#   # # Manifest Push alpine-amd64
+#   # docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+# }
 
 setup_dependencies() {
   echo "PREPARE: Setting up dependencies."

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+set -o errexit
+
+main() {
+    case $1 in
+        "prepare")
+            docker_prepare
+            ;;
+        "build")
+            docker_build
+            ;;
+        "test")
+            docker_test
+            ;;
+        "tag")
+            docker_tag
+            ;;
+        "push")
+            docker_push
+            ;;
+        "manifest-list")
+            docker_manifest_list
+            ;;
+        *)
+            echo "none of above!"
+    esac
+}
+
+docker_prepare() {
+    # Prepare the machine before any code installation scripts
+    setup_dependencies
+
+    # Update docker configuration to enable docker manifest command
+    update_docker_configuration
+
+    # Prepare qemu to build images other then x86_64 on travis
+    prepare_qemu
+}
+
+docker_build() {
+    # Build Docker image
+    echo "DOCKER BUILD: Build Docker image."
+    echo "DOCKER BUILD: build version - ${BUILD_VERSION}."
+    echo "DOCKER BUILD: build from - ${BUILD_FROM}."
+    echo "DOCKER BUILD: qemu arch - ${QEMU_ARCH}."
+    echo "DOCKER BUILD: os arch - ${OS_ARCH}."
+    echo "DOCKER BUILD: docker file - ${DOCKER_FILE}."
+
+    docker build --build-arg BUILD_REF=${TRAVIS_COMMIT} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=${BUILD_FROM} --build-arg QEMU_ARCH=${QEMU_ARCH} --file ./.docker/${DOCKER_FILE} --tag ${TARGET}:build-${OS_ARCH} .
+}
+
+docker_test() {
+    echo "DOCKER TEST: Test Docker image."
+    echo "DOCKER TEST: testing image - test-${OS_ARCH}."
+
+    docker run -d --rm --name=test-${OS_ARCH} ${TARGET}:build-${OS_ARCH}
+    if [ $? -ne 0 ]; then
+       echo "DOCKER TEST: FAILED - Docker container test-${OS_ARCH} failed to start."
+       exit 1
+    else
+       echo "DOCKER TEST: PASSED - Docker container test-${OS_ARCH} succeeded to start."
+    fi
+}
+
+docker_tag() {
+    echo "DOCKER TAG: Tag Docker image."
+    echo "DOCKER TAG: tagging image - ${TARGET}:${BUILD_VERSION}-${OS_ARCH}."
+    docker tag ${TARGET}:build-${OS_ARCH} ${TARGET}:${BUILD_VERSION}-${OS_ARCH}
+}
+
+docker_push() {
+    echo "DOCKER PUSH: Push Docker image."
+    echo "DOCKER PUSH: pushing - ${TARGET}:${BUILD_VERSION}-${OS_ARCH}."
+    docker push ${TARGET}:${BUILD_VERSION}-${OS_ARCH}
+}
+
+docker_manifest_list() {
+    # Create and push manifest lists, displayed as FIFO
+    echo "DOCKER MANIFEST: Create and Push docker manifest lists."
+    docker_manifest_list_version
+    docker_manifest_list_latest
+    docker_manifest_list_version_os_arch
+}
+
+docker_manifest_list_version() {
+  # Manifest Create BUILD_VERSION
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}."
+  docker manifest create ${TARGET}:${BUILD_VERSION} \
+      ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+      ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+
+  # Manifest Annotate BUILD_VERSION
+  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+
+  # Manifest Push BUILD_VERSION
+  docker manifest push ${TARGET}:${BUILD_VERSION}
+}
+
+docker_manifest_list_latest() {
+  # Manifest Create latest
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:latest."
+  docker manifest create ${TARGET}:latest \
+      ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+      ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+
+  # Manifest Annotate BUILD_VERSION
+  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+
+  # Manifest Push BUILD_VERSION
+  docker manifest push ${TARGET}:latest
+}
+
+docker_manifest_list_version_os_arch() {
+  # Manifest Create alpine-amd64
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-amd64."
+  docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
+      ${TARGET}:${BUILD_VERSION}-alpine-amd64
+
+  # Manifest Push alpine-amd64
+  docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-amd64
+
+  # Manifest Create slim-arm32v7
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-slim-arm32v7."
+  docker manifest create ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+      ${TARGET}:${BUILD_VERSION}-slim-arm32v7
+
+  # Manifest Annotate slim-arm32v7
+  docker manifest annotate ${TARGET}:${BUILD_VERSION}-slim-arm32v7 ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+
+  # Manifest Push slim-arm32v7
+  docker manifest push ${TARGET}:${BUILD_VERSION}-slim-arm32v7
+
+  # Manifest Create alpine-arm64v8
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-arm64v8."
+  docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+
+  # Manifest Annotate alpine-arm64v8
+  docker manifest annotate ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+
+  # Manifest Push alpine-amd64
+  docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+}
+
+setup_dependencies() {
+  echo "PREPARE: Setting up dependencies."
+
+  sudo apt update -y
+  # sudo apt install realpath python python-pip -y
+  sudo apt install --only-upgrade docker-ce -y
+  # sudo pip install docker-compose || true
+
+  docker info
+  # docker-compose --version
+}
+
+update_docker_configuration() {
+  echo "PREPARE: Updating docker configuration"
+
+  mkdir $HOME/.docker
+
+  # enable experimental to use docker manifest command
+  echo '{
+    "experimental": "enabled"
+  }' | tee $HOME/.docker/config.json
+
+  # # enable experimental
+  # echo '{
+  #   "experimental": true,
+  #   "storage-driver": "overlay2",
+  #   "max-concurrent-downloads": 100,
+  #   "max-concurrent-uploads": 100
+  # }' | sudo tee /etc/docker/daemon.json
+
+  # sudo service docker restart
+}
+
+prepare_qemu(){
+    echo "PREPARE: Qemu"
+    # Prepare qemu to build non amd64 / x86_64 images
+    docker run --rm --privileged multiarch/qemu-user-static:register --reset
+    mkdir tmp
+    pushd tmp &&
+    curl -L -o qemu-x86_64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-x86_64-static.tar.gz && tar xzf qemu-x86_64-static.tar.gz &&
+    curl -L -o qemu-arm-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-arm-static.tar.gz && tar xzf qemu-arm-static.tar.gz &&
+    curl -L -o qemu-aarch64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-aarch64-static.tar.gz && tar xzf qemu-aarch64-static.tar.gz &&
+    popd
+}
+
+main $1

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -74,77 +74,82 @@ docker_push() {
     docker push ${TARGET}:${BUILD_VERSION}-${OS_ARCH}
 }
 
-# docker_manifest_list() {
-#     # Create and push manifest lists, displayed as FIFO
-#     echo "DOCKER MANIFEST: Create and Push docker manifest lists."
-#     docker_manifest_list_version
-#     docker_manifest_list_latest
-#     docker_manifest_list_version_os_arch
-# }
-#
-# docker_manifest_list_version() {
-#   # Manifest Create BUILD_VERSION
-#   echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}."
-#   docker manifest create ${TARGET}:${BUILD_VERSION} \
-#       #${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-#       #${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-#       ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
-#
-#   # Manifest Annotate BUILD_VERSION
-#   #docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-#   docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm32 --variant=v6
-#
-#   # Manifest Push BUILD_VERSION
-#   docker manifest push ${TARGET}:${BUILD_VERSION}
-# }
-#
-# docker_manifest_list_latest() {
-#   # Manifest Create latest
-#   echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:latest."
-#   docker manifest create ${TARGET}:latest \
-#       # ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-#       # ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-#       ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
-#
-#   # Manifest Annotate BUILD_VERSION
-#   # docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-#   docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm32 --variant=v6
-#
-#   # Manifest Push BUILD_VERSION
-#   docker manifest push ${TARGET}:latest
-# }
-#
-# docker_manifest_list_version_os_arch() {
-#   # # Manifest Create alpine-amd64
-#   # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-amd64."
-#   # docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-amd64 \
-#   #     ${TARGET}:${BUILD_VERSION}-alpine-amd64
-#   #
-#   # # Manifest Push alpine-amd64
-#   # docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-amd64
-#   #
-#   # # Manifest Create slim-arm32v7
-#   # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-slim-arm32v7."
-#   # docker manifest create ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
-#   #     ${TARGET}:${BUILD_VERSION}-slim-arm32v7
-#   #
-#   # # Manifest Annotate slim-arm32v7
-#   # docker manifest annotate ${TARGET}:${BUILD_VERSION}-slim-arm32v7 ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
-#   #
-#   # # Manifest Push slim-arm32v7
-#   # docker manifest push ${TARGET}:${BUILD_VERSION}-slim-arm32v7
-#
-#   # # Manifest Create alpine-arm64v8
-#   # echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-arm64v8."
-#   # docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 \
-#   #     ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
-#   #
-#   # # Manifest Annotate alpine-arm64v8
-#   # docker manifest annotate ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
-#   #
-#   # # Manifest Push alpine-amd64
-#   # docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
-# }
+docker_manifest_list() {
+    # Create and push manifest lists, displayed as FIFO
+    echo "DOCKER MANIFEST: Create and Push docker manifest lists."
+    docker_manifest_list_version
+    docker_manifest_list_latest
+    docker_manifest_list_version_os_arch
+}
+
+docker_manifest_list_version() {
+  # Manifest Create BUILD_VERSION
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}."
+  docker manifest create ${TARGET}:${BUILD_VERSION} \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 \
+      ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+
+  # Manifest Annotate BUILD_VERSION
+  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm --variant=v6
+  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:${BUILD_VERSION} ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+
+  # Manifest Push BUILD_VERSION
+  docker manifest push ${TARGET}:${BUILD_VERSION}
+}
+
+docker_manifest_list_latest() {
+  # Manifest Create latest
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:latest."
+  docker manifest create ${TARGET}:latest \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 \
+      ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+      ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+
+  # Manifest Annotate BUILD_VERSION
+  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm --variant=v6
+  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:latest ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+
+  # Manifest Push BUILD_VERSION
+  docker manifest push ${TARGET}:latest
+}
+
+docker_manifest_list_version_os_arch() {
+  # Manifest Create alpine-arm32v6
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-arm32v6."
+  docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 \
+    ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
+
+  # Manifest Annotate alpine-arm32v6
+  docker manifest annotate ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 ${TARGET}:${BUILD_VERSION}-alpine-arm32v6 --os=linux --arch=arm --variant=v6
+
+  # Manifest Push alpine-arm32v6
+  docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-arm32v6
+
+  # Manifest Create slim-arm32v7
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-slim-arm32v7."
+  docker manifest create ${TARGET}:${BUILD_VERSION}-slim-arm32v7 \
+    ${TARGET}:${BUILD_VERSION}-slim-arm32v7
+
+  # Manifest Annotate slim-arm32v7
+  docker manifest annotate ${TARGET}:${BUILD_VERSION}-slim-arm32v7 ${TARGET}:${BUILD_VERSION}-slim-arm32v7 --os=linux --arch=arm --variant=v7
+
+  # Manifest Push slim-arm32v7
+  docker manifest push ${TARGET}:${BUILD_VERSION}-slim-arm32v7
+
+  # Manifest Create alpine-arm64v8
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${BUILD_VERSION}-alpine-arm64v8."
+  docker manifest create ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 \
+    ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+
+  # Manifest Annotate alpine-arm64v8
+  docker manifest annotate ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 ${TARGET}:${BUILD_VERSION}-alpine-arm64v8 --os=linux --arch=arm64 --variant=v8
+
+  # Manifest Push alpine-arm64v8
+  docker manifest push ${TARGET}:${BUILD_VERSION}-alpine-arm64v8
+}
 
 setup_dependencies() {
   echo "PREPARE: Setting up dependencies."

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
 
               # Create and Push Docker Manifest Lists to Docker Hub
               - echo "Create manifest list for all docker images."
-              #- ./.docker/docker.sh manifest-list
+              - ./.docker/docker.sh manifest-list
 
               # Docker Logout
               - docker logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
         - QEMU_VERSION=v3.0.0
     matrix:
         - BUILD_FROM=arm32v6/python:3-alpine3.8 QEMU_ARCH=arm OS_ARCH=alpine-arm32v6 DOCKER_FILE=Dockerfile.alpine-tmpl
-        - BUILD_FROM=arm32v7/python:3-slim QEMU_ARCH=arm OS_ARCH=alpine-arm32v7 DOCKER_FILE=Dockerfile.slim-tmpl
+        - BUILD_FROM=arm32v7/python:3-slim QEMU_ARCH=arm OS_ARCH=slim-arm32v7 DOCKER_FILE=Dockerfile.slim-tmpl
         - BUILD_FROM=arm64v8/python:3-alpine3.8 QEMU_ARCH=aarch64 OS_ARCH=alpine-arm64v8 DOCKER_FILE=Dockerfile.alpine-tmpl
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
         - QEMU_VERSION=v3.0.0
     matrix:
         - BUILD_FROM=arm32v6/python:3-alpine3.8 QEMU_ARCH=arm OS_ARCH=alpine-arm32v6 DOCKER_FILE=Dockerfile.alpine-tmpl
+        - BUILD_FROM=arm32v6/python:3-alpine3.8 QEMU_ARCH=arm OS_ARCH=alpine-arm32v6 DOCKER_FILE=Dockerfile.alpine-tmpl
 
 before_install:
   - ./.docker/docker.sh prepare

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,66 @@
+sudo: 'required'
+
+services:
+  - 'docker'
+
+language:
+  - 'bash'
+
+env:
+    global:
+        - TARGET=raymondmm/miflora-mqtt
+        - QEMU_VERSION=v3.0.0
+    matrix:
+        - BUILD_FROM=arm32v6/python:3-alpine3.8 QEMU_ARCH=arm OS_ARCH=alpine-arm32v6 DOCKER_FILE=Dockerfile.alpine-tmpl
+
+before_install:
+  - ./.docker/docker.sh prepare
+
+install: true
+
+before_script:
+    # Set BUILD_VERSION
+    - if [ ! -z "${TRAVIS_TAG}" ]; then export BUILD_VERSION=${TRAVIS_TAG}; else export BUILD_VERSION=v2.3.8; fi
+
+script:
+    # Build Docker image
+    - ./.docker/docker.sh build
+
+    # Test Docker image
+    - ./.docker/docker.sh test
+
+    # Push Docker image (TODO move to function)
+    - >
+      if [ ! -z "${TRAVIS_TAG}" ]; then
+        # Tag Docker image
+        ./.docker/docker.sh tag
+
+        # Docker Login
+        echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+
+        # Push Docker image
+        docker push ${TARGET}:${BUILD_VERSION}-${OS_ARCH}
+
+        # Docker Logout
+        docker logout
+      fi
+
+jobs:
+    include:
+        - stage: manifest
+          if: tag =~ ^v
+          script:
+              # Create and push Docker manifest lists (TODO move to function)
+              # Docker Login
+              - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+              # Create and Push Docker Manifest Lists to Docker Hub
+              - echo "Create manifest list for all docker images."
+              - ./.docker/docker.sh manifest-list
+
+              # Docker Logout
+              - docker logout
+
+# notify me when things fail
+notifications:
+    email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
         - QEMU_VERSION=v3.0.0
     matrix:
         - BUILD_FROM=arm32v6/python:3-alpine3.8 QEMU_ARCH=arm OS_ARCH=alpine-arm32v6 DOCKER_FILE=Dockerfile.alpine-tmpl
-        - BUILD_FROM=arm32v6/python:3-alpine3.8 QEMU_ARCH=arm OS_ARCH=alpine-arm32v6 DOCKER_FILE=Dockerfile.alpine-tmpl
+        - BUILD_FROM=arm32v7/python:3-slim QEMU_ARCH=arm OS_ARCH=alpine-arm32v7 DOCKER_FILE=Dockerfile.slim-tmpl
 
 before_install:
   - ./.docker/docker.sh prepare

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
 
               # Create and Push Docker Manifest Lists to Docker Hub
               - echo "Create manifest list for all docker images."
-              - ./.docker/docker.sh manifest-list
+              #- ./.docker/docker.sh manifest-list
 
               # Docker Logout
               - docker logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     matrix:
         - BUILD_FROM=arm32v6/python:3-alpine3.8 QEMU_ARCH=arm OS_ARCH=alpine-arm32v6 DOCKER_FILE=Dockerfile.alpine-tmpl
         - BUILD_FROM=arm32v7/python:3-slim QEMU_ARCH=arm OS_ARCH=alpine-arm32v7 DOCKER_FILE=Dockerfile.slim-tmpl
+        - BUILD_FROM=arm64v8/python:3-alpine3.8 QEMU_ARCH=aarch64 OS_ARCH=alpine-arm64v8 DOCKER_FILE=Dockerfile.alpine-tmpl
 
 before_install:
   - ./.docker/docker.sh prepare

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This can be done either by using the internal daemon or cron.
 **Attention:** Daemon mode must be enabled in the configuration file (default).
 
 1. Systemd service - on systemd powered systems the **recommended** option
-   
+
    ```shell
    sudo cp /opt/miflora-mqtt-daemon/template.service /etc/systemd/system/miflora.service
 
@@ -142,33 +142,59 @@ This can be done either by using the internal daemon or cron.
    ```
 
 1. Screen Shell - Run the program inside a [screen shell](https://www.howtoforge.com/linux_screen):
-   
+
    ```shell
    screen -S miflora-mqtt-daemon -d -m python3 /path/to/miflora-mqtt-daemon.py
    ```
 
-## Usage with Docker
+## Docker usage with pre-defined images
+[Docker Hub](https://hub.docker.com/r/raymondmm/miflora-mqtt/) provides pre-defined Docker images for:
+- arm32v6
+- arm32v7
+- arm64v8
 
-A Dockerfile in the repository can be used to build a docker container from the sources with a command such as:
-
-```shell
-docker build -t miflora-mqtt-daemon .
-```
+These images are pushed using manifest-list which means one doesn't need to provide tagging for the host architecture. Docker will determine automatically and pull the right image automatically.
 
 Running the container in interactive mode works like this:
 
 ```shell
-docker run -it --name miflora-mqtt-daemon -v .:/config miflora-mqtt-daemon
+docker run -it --name miflora-mqtt-daemon -v .:/config raymondmm/miflora-mqtt-daemon:latest
 ```
 
 To run the container in daemon mode use `-d` flag:
 
 ```shell
-docker run -d --name miflora-mqtt-daemon -v .:/config miflora-mqtt-daemon
+docker run -d --name miflora-mqtt-daemon -v .:/config raymondmm/miflora-mqtt-daemon:latest
 ```
 
+If for some reason one wants to use the image for a certain architecture, just add associated tag:
+
+```shell
+docker run -it --name miflora-mqtt-daemon -v .:/config raymondmm/miflora-mqtt-daemon:v0.1.0-alpine-arm32v6
+```
+
+or
+
+```shell
+docker run -it --name miflora-mqtt-daemon -v .:/config raymondmm/miflora-mqtt-daemon:v0.1.0-slim-arm32v7
+```
+
+or
+
+```shell
+docker run -it --name miflora-mqtt-daemon -v .:/config raymondmm/miflora-mqtt-daemon:v0.1.0-slim-arm64v8
+```
+
+### Docker persistence
 The `/config` volume can be used to provide a directory on the host which contains your `config.ini` file (e.g. the `.` in the above example could represent `/opt/miflora-mqtt-daemon`).
 You may need to tweak the network settings (e.g. `--network host`) for Docker depending on how your system is set up.
+
+### Build custom Docker image
+The Dockerfile in the root of the repository can be used to build a custom docker image from the sources with a command such as:
+
+```shell
+docker build -t miflora-mqtt-daemon .
+```
 
 ## Integration
 
@@ -218,9 +244,8 @@ Number Balcony_Petunia_Light "Balcony Petunia Sunlight Intensity [%d lux]" <text
 #### Disclaimer and Legal
 
 > *Xiaomi* and *Mi Flora* are registered trademarks of *BEIJING XIAOMI TECHNOLOGY CO., LTD.*
-> 
+>
 > This project is a community project not for commercial use.
 > The authors will not be held responsible in the event of device failure or withered plants.
-> 
+>
 > This project is in no way affiliated with, authorized, maintained, sponsored or endorsed by *Xiaomi* or any of its affiliates or subsidiaries.
-

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [! -f "/opt/miflora-mqtt-daemon/config/config.ini"]; then
+if [ ! -f "/opt/miflora-mqtt-daemon/config/config.ini" ]; then
   echo 'Mi-Flora mqtt config does not exists, create default.'
   mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini
 fi

--- a/start.sh
+++ b/start.sh
@@ -5,4 +5,4 @@ if [ ! -f "/opt/miflora-mqtt-daemon/config/config.ini" ]; then
 fi
 
 # Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon
-python3 /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py --config /opt/miflora-config
+python3 /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py --config /opt/miflora-mqtt-daemon/config

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [! -f "/opt/miflora-mqtt-daemon/config/config.ini"]; then
+  echo 'Mi-Flora mqtt config does not exists, create default.'
+  mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini
+fi
+
+# Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon
+python3 /opt/miflora-mqtt-daemon/miflora-mqtt-daemon.py --config /opt/miflora-config

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ ! -f "/opt/miflora-mqtt-daemon/config/config.ini" ]; then
   echo 'Mi-Flora mqtt config does not exists, create default.'
-  mv /opt/miflora-mqtt-daemon/config/config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini
+  cp /opt/miflora-mqtt-daemon/config/config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini
 fi
 
 # Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ ! -f "/opt/miflora-mqtt-daemon/config/config.ini" ]; then
   echo 'Mi-Flora mqtt config does not exists, create default.'
-  mv /tmp/config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini
+  mv /opt/miflora-mqtt-daemon/config/config.ini.dist /opt/miflora-mqtt-daemon/config/config.ini
 fi
 
 # Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon


### PR DESCRIPTION
Hello Thom,

I took the opportunity to create docker images for the architectures **arm32v6, arm32v7 and arm64v8**, so that users of RPI 1, 2, 3 and Zero can run miflora-mqtt-daemon within a docker container without building the image by there self. The readme is update accordingly.

The build process is automated by [Travis](https://travis-ci.org), which gets triggered by a github commit. When such commit is is done, then Travis checks if it is a [release](https://github.com/ThomDietrich/miflora-mqtt-daemon/releases), if yes then the images are build and tested and pushed to [Docker Hub](https://hub.docker.com/r/raymondmm/miflora-mqtt/tags/), if not the images are build and tested but *not* pushed to Docker Hub.

I've not found the time to run the images yet, but I will do that asap.

Hope you appreciate the work.

Best regards,
Raymond

