### PR TITLE
posibility to upload MQTT data to thingsboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This can be done either by using the internal daemon or cron.
 **Attention:** Daemon mode must be enabled in the configuration file (default).
 
 1. Systemd service - on systemd powered systems the **recommended** option
-   
+
    ```shell
    sudo cp /opt/miflora-mqtt-daemon/template.service /etc/systemd/system/miflora.service
 
@@ -142,7 +142,7 @@ This can be done either by using the internal daemon or cron.
    ```
 
 1. Screen Shell - Run the program inside a [screen shell](https://www.howtoforge.com/linux_screen):
-   
+
    ```shell
    screen -S miflora-mqtt-daemon -d -m python3 /path/to/miflora-mqtt-daemon.py
    ```
@@ -216,15 +216,20 @@ Number Balcony_Petunia_Light "Balcony Petunia Sunlight Intensity [%d lux]" <text
 Paste the presented items definition into an openHAB items file and you are ready to go.
 Be sure to install the used MQTT Binding and JSONPath Transformation openHAB addons beforehand.
 
+### ThingsBoard
+
+to integrate with thingsboard.io
+1. in the `config.ini` set `reporting_method = thingsboard-json`
+1. in the `config.ini` the sensor names have to be unique
+1. in ThingsBoard create devices and use `Access token` as `Credential type` and the sensor name used in the `config.ini` as token
 
 ----
 
 #### Disclaimer and Legal
 
 > *Xiaomi* and *Mi Flora* are registered trademarks of *BEIJING XIAOMI TECHNOLOGY CO., LTD.*
-> 
+>
 > This project is a community project not for commercial use.
 > The authors will not be held responsible in the event of device failure or withered plants.
-> 
+>
 > This project is in no way affiliated with, authorized, maintained, sponsored or endorsed by *Xiaomi* or any of its affiliates or subsidiaries.
-

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The program can be executed in **daemon mode** to run continuously in the backgr
     * following the [Homie Convention v2.0.5](https://github.com/marvinroger/homie)
     * following the [mqtt-smarthome architecture proposal](https://github.com/mqtt-smarthome/mqtt-smarthome)
     * using the [HomeAssistant MQTT discovery format](https://home-assistant.io/docs/mqtt/discovery/)
+    * using the [ThingsBoard.io](https://thingsboard.io/) MQTT interface
 * Announcement messages to support auto-discovery services
 * MQTT authentication support
 * No special/root privileges needed
@@ -129,7 +130,7 @@ This can be done either by using the internal daemon or cron.
 **Attention:** Daemon mode must be enabled in the configuration file (default).
 
 1. Systemd service - on systemd powered systems the **recommended** option
-
+   
    ```shell
    sudo cp /opt/miflora-mqtt-daemon/template.service /etc/systemd/system/miflora.service
 
@@ -142,7 +143,7 @@ This can be done either by using the internal daemon or cron.
    ```
 
 1. Screen Shell - Run the program inside a [screen shell](https://www.howtoforge.com/linux_screen):
-
+   
    ```shell
    screen -S miflora-mqtt-daemon -d -m python3 /path/to/miflora-mqtt-daemon.py
    ```
@@ -218,18 +219,19 @@ Be sure to install the used MQTT Binding and JSONPath Transformation openHAB add
 
 ### ThingsBoard
 
-to integrate with thingsboard.io
-1. in the `config.ini` set `reporting_method = thingsboard-json`
-1. in the `config.ini` the sensor names have to be unique
-1. in ThingsBoard create devices and use `Access token` as `Credential type` and the sensor name used in the `config.ini` as token
+to integrate with [ThingsBoard.io](https://thingsboard.io/):
+
+1. in your `config.ini` set `reporting_method = thingsboard-json`
+1. in your `config.ini` assign unique sensor names for your plants
+1. on the ThingsBoard platform create devices and use `Access token` as `Credential type` and the chosen sensor name as token
 
 ----
 
 #### Disclaimer and Legal
 
 > *Xiaomi* and *Mi Flora* are registered trademarks of *BEIJING XIAOMI TECHNOLOGY CO., LTD.*
->
+> 
 > This project is a community project not for commercial use.
 > The authors will not be held responsible in the event of device failure or withered plants.
->
+> 
 > This project is in no way affiliated with, authorized, maintained, sponsored or endorsed by *Xiaomi* or any of its affiliates or subsidiaries.

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -15,7 +15,7 @@
 #                       (https://github.com/mqtt-smarthome/mqtt-smarthome)
 #  homeassistant-mqtt - Publish to an MQTT broker following the HomeAssistant discovery format
 #                       (https://www.home-assistant.io/docs/mqtt/discovery/)
-#  thingsboard-json   - Publish to ThingsBoard as MQTT broker
+#    thingsboard-json - Publish to the ThingsBoard MQTT broker
 #                       (https://thingsboard.io)
 #                json - Print to stdout as json encoded strings
 #

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -44,9 +44,11 @@
 #keepalive = 60
 
 # The MQTT base topic to publish all Mi Flora sensor data topics under.
-# Default depends on the configured reporting_mode (mqtt-json, mqtt-smarthome: miflora, mqtt-homie: homie)
-#base_topic = miflora
-#base_topic = homie
+# Default depends on the configured reporting_method
+#base_topic = miflora                   # Default for: mqtt-json, mqtt-smarthome
+#base_topic = homie                     # Default for: mqtt-homie
+#base_topic = homeassistant             # Default for: homeassistant-mqtt
+#base_topic = v1/devices/me/telemetry   # Default for: thingsboard-json
 
 # Homie specific: The device ID for this daemon instance (Default: miflora-mqtt-daemon)
 #homie_device_id = miflora-mqtt-daemon

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -9,12 +9,14 @@
 # Currently supported:
 #
 #           mqtt-json - Publish to an MQTT broker in a proprietary json format (Default)
-#          mqtt-homie - Publish to an MQTT broker following the Homie MQTT convention 
+#          mqtt-homie - Publish to an MQTT broker following the Homie MQTT convention
 #                       (https://github.com/marvinroger/homie)
 #      mqtt-smarthome - Publish to an MQTT broker following the mqtt-smarthome proposal
 #                       (https://github.com/mqtt-smarthome/mqtt-smarthome)
 #  homeassistant-mqtt - Publish to an MQTT broker following the HomeAssistant discovery format
 #                       (https://www.home-assistant.io/docs/mqtt/discovery/)
+#  thingsboard-json   - Publish to ThingsBoard as MQTT broker
+#                       (https://thingsboard.io)
 #                json - Print to stdout as json encoded strings
 #
 #reporting_method = mqtt-json
@@ -77,4 +79,3 @@
 #Schefflera@Living = C4:7C:8D:11:22:33
 #JapaneseBonsai    = C4:7C:8D:44:55:66
 #Petunia@Balcony   = C4:7C:8D:77:88:99
-

--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -178,10 +178,9 @@ if reporting_mode in ['mqtt-json', 'mqtt-homie', 'mqtt-smarthome', 'homeassistan
     if config['MQTT'].get('username'):
         mqtt_client.username_pw_set(config['MQTT'].get('username'), config['MQTT'].get('password', None))
     try:
-        if reporting_mode != 'thingsboard-json':
-            mqtt_client.connect(config['MQTT'].get('hostname', 'localhost'),
-                                port=config['MQTT'].getint('port', 1883),
-                                keepalive=config['MQTT'].getint('keepalive', 60))
+        mqtt_client.connect(config['MQTT'].get('hostname', 'localhost'),
+                            port=config['MQTT'].getint('port', 1883),
+                            keepalive=config['MQTT'].getint('keepalive', 60))
     except:
         print_line('MQTT connection error. Please check your settings in the configuration file "config.ini"', error=True, sd_notify=True)
         sys.exit(1)
@@ -341,7 +340,7 @@ while True:
         for param,_ in parameters.items():
             data[param] = flora['poller'].parameter_value(param)
         print_line('Result: {}'.format(json.dumps(data)))
-        
+
         if reporting_mode == 'mqtt-json':
             print_line('Publishing to MQTT topic "{}/{}"'.format(base_topic, flora_name))
             mqtt_client.publish('{}/{}'.format(base_topic, flora_name), json.dumps(data))
@@ -349,9 +348,7 @@ while True:
         elif reporting_mode == 'thingsboard-json':
             print_line('Publishing to MQTT topic "{}" username "{}"'.format(base_topic, flora_name))
             mqtt_client.username_pw_set(flora_name)
-            mqtt_client.connect(config['MQTT'].get('hostname', 'localhost'),
-                                port=config['MQTT'].getint('port', 1883),
-                                keepalive=config['MQTT'].getint('keepalive', 60))
+            mqtt_client.reconnect()
             sleep(1.0)
             mqtt_client.publish('{}'.format(base_topic), json.dumps(data))
             sleep(0.5) # some slack for the publish roundtrip and callback function


### PR DESCRIPTION
this add the possibility to use the script with https://thingsboard.io
thingsboard wants the data to be published to `v1/devices/me/telemetry` (without any device name) and a token is used as username. The token is also used to determine which device is used

I've changed the script so that the sensors-name is used as token