### PR TITLE
Client ID added as configurable parameter

### DIFF
--- a/config.ini.dist
+++ b/config.ini.dist
@@ -40,6 +40,9 @@
 # The TCP port the MQTT broker is listening on (Default: 1883)
 #port = 1883
 
+# The client identifier that identifies this MQTT client (Default: miflora)
+#client_id = miflora
+
 # Maximum period in seconds between ping messages to the broker. (Default: 60)
 #keepalive = 60
 

--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -154,7 +154,7 @@ print_line('Configuration accepted', console=False, sd_notify=True)
 # MQTT connection
 if reporting_mode in ['mqtt-json', 'mqtt-homie', 'mqtt-smarthome', 'homeassistant-mqtt', 'thingsboard-json']:
     print_line('Connecting to MQTT broker ...')
-    mqtt_client = mqtt.Client()
+    mqtt_client = mqtt.Client(client_id = config['MQTT'].get('client_id', 'miflora'))
     mqtt_client.on_connect = on_connect
     mqtt_client.on_publish = on_publish
     if reporting_mode == 'mqtt-json':


### PR DESCRIPTION
The Client ID has been added as a configurable parameter.

For the internal OpenHab MQTT broker (moquette) the client ID can not be empty. The bug has been fixed and the client can connect to the broker.

Fixes #55 