### PR TITLE
Update paho-mqtt to 1.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 #git+https://github.com/open-homeautomation/miflora.git#egg=miflora
 miflora==0.4
-paho-mqtt==1.3.0
+paho-mqtt==1.4.0
 wheel==0.29.0
 sdnotify==0.3.1
 colorama==0.3.9


### PR DESCRIPTION
Connection to java moquette mqtt broker (also used with internal openhab 2.4 broker) fails because no client ID is generated. The bug has been fixed in paho-mqtt since version 1.3.1: https://github.com/eclipse/paho.mqtt.python/commit/6b6198ec3057bb81142d2f1ba4644502cc85f821

This PR fixed #55.