### PR TITLE
Added support for Wiren Board MQTT Conventions

### DIFF
--- a/config.ini.dist
+++ b/config.ini.dist
@@ -17,6 +17,8 @@
 #                       (https://www.home-assistant.io/docs/mqtt/discovery/)
 #    thingsboard-json - Publish to the ThingsBoard MQTT broker
 #                       (https://thingsboard.io)
+#    wirenboard-mqtt -  Publish to the Wiren Board MQTT broker
+#                       (https://wirenboard.com)
 #                json - Print to stdout as json encoded strings
 #
 #reporting_method = mqtt-json
@@ -49,6 +51,7 @@
 #base_topic = homie                     # Default for: mqtt-homie
 #base_topic = homeassistant             # Default for: homeassistant-mqtt
 #base_topic = v1/devices/me/telemetry   # Default for: thingsboard-json
+#base_topic =                           # Default for: wirenboard-mqtt
 
 # Homie specific: The device ID for this daemon instance (Default: miflora-mqtt-daemon)
 #homie_device_id = miflora-mqtt-daemon

--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -150,6 +150,9 @@ if reporting_mode not in ['mqtt-json', 'mqtt-homie', 'json', 'mqtt-smarthome', '
 if not config['Sensors']:
     print_line('No sensors found in configuration file "config.ini"', error=True, sd_notify=True)
     sys.exit(1)
+if reporting_mode == 'wirenboard-mqtt' and base_topic:
+    print_line('Parameter "base_topic" ignored for "reporting_method = wirenboard-mqtt"', warning=True, sd_notify=True)
+
 
 print_line('Configuration accepted', console=False, sd_notify=True)
 

--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -133,6 +133,8 @@ elif reporting_mode == 'homeassistant-mqtt':
     default_base_topic = 'homeassistant'
 elif reporting_mode == 'thingsboard-json':
     default_base_topic = 'v1/devices/me/telemetry'
+elif reporting_mode == 'wirenboard-mqtt':
+    default_base_topic = ''
 else:
     default_base_topic = 'miflora'
 
@@ -142,7 +144,7 @@ sleep_period = config['Daemon'].getint('period', 300)
 miflora_cache_timeout = sleep_period - 1
 
 # Check configuration
-if reporting_mode not in ['mqtt-json', 'mqtt-homie', 'json', 'mqtt-smarthome', 'homeassistant-mqtt', 'thingsboard-json']:
+if reporting_mode not in ['mqtt-json', 'mqtt-homie', 'json', 'mqtt-smarthome', 'homeassistant-mqtt', 'thingsboard-json', 'wirenboard-mqtt']:
     print_line('Configuration parameter reporting_mode set to an invalid value', error=True, sd_notify=True)
     sys.exit(1)
 if not config['Sensors']:
@@ -152,7 +154,7 @@ if not config['Sensors']:
 print_line('Configuration accepted', console=False, sd_notify=True)
 
 # MQTT connection
-if reporting_mode in ['mqtt-json', 'mqtt-homie', 'mqtt-smarthome', 'homeassistant-mqtt', 'thingsboard-json']:
+if reporting_mode in ['mqtt-json', 'mqtt-homie', 'mqtt-smarthome', 'homeassistant-mqtt', 'thingsboard-json', 'wirenboard-mqtt']:
     print_line('Connecting to MQTT broker ...')
     mqtt_client = mqtt.Client()
     mqtt_client.on_connect = on_connect
@@ -303,6 +305,22 @@ elif reporting_mode == 'homeassistant-mqtt':
             if 'device_class' in params:
                 payload['device_class'] = params['device_class']
             mqtt_client.publish('{}/{}_{}/config'.format(topic_path, flora_name, sensor).lower(), json.dumps(payload), 1, True)
+elif reporting_mode == 'wirenboard-mqtt':
+    print_line('Announcing Mi Flora devices to MQTT broker for auto-discovery ...')
+    for [flora_name, flora] in flores.items():
+        mqtt_client.publish('/devices/{}/meta/name'.format(flora_name), flora_name, 1, True)
+        topic_path = '/devices/{}/controls'.format(flora_name)
+        mqtt_client.publish('{}/battery/meta/type'.format(topic_path), 'value', 1, True)
+        mqtt_client.publish('{}/battery/meta/units'.format(topic_path), '%', 1, True)
+        mqtt_client.publish('{}/conductivity/meta/type'.format(topic_path), 'value', 1, True)
+        mqtt_client.publish('{}/conductivity/meta/units'.format(topic_path), 'µS/cm', 1, True)
+        mqtt_client.publish('{}/light/meta/type'.format(topic_path), 'value', 1, True)
+        mqtt_client.publish('{}/light/meta/units'.format(topic_path), 'lux', 1, True)
+        mqtt_client.publish('{}/moisture/meta/type'.format(topic_path), 'rel_humidity', 1, True)
+        mqtt_client.publish('{}/temperature/meta/type'.format(topic_path), 'temperature', 1, True)
+        mqtt_client.publish('{}/timestamp/meta/type'.format(topic_path), 'text', 1, True)
+    sleep(0.5) # some slack for the publish roundtrip and callback function
+    print()
 
 print_line('Initialization complete, starting MQTT publish loop', console=False, sd_notify=True)
 
@@ -368,6 +386,12 @@ while True:
                 payload['val'] = value
                 payload['ts'] = int(round(time() * 1000))
                 mqtt_client.publish('{}/status/{}/{}'.format(base_topic, flora_name, param), json.dumps(payload), retain=True)
+            sleep(0.5)  # some slack for the publish roundtrip and callback function
+        elif reporting_mode == 'wirenboard-mqtt':
+            for [param, value] in data.items():
+                print_line('Publishing data to MQTT topic "/devices/{}/controls/{}"'.format(flora_name, param))
+                mqtt_client.publish('/devices/{}/controls/{}'.format(flora_name, param), value, retain=True)
+            mqtt_client.publish('/devices/{}/controls/{}'.format(flora_name, 'timestamp'), strftime('%Y-%m-%d %H:%M:%S', localtime()), retain=True)
             sleep(0.5)  # some slack for the publish roundtrip and callback function
         elif reporting_mode == 'json':
             data['timestamp'] = strftime('%Y-%m-%d %H:%M:%S', localtime())


### PR DESCRIPTION
Added support for [Wiren Board](https://wirenboard.com/en/) controller that uses [homeA-like MQTT conventions](https://github.com/binarybucks/homA/wiki/Conventions). This conventions are published [here](https://github.com/contactless/homeui/blob/master/conventions.md)