### PR TITLE
Support for reading MQTT config options from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ sudo hcitool lescan
 Interfacing your Mi Flora sensor with this program is harmless.
 The device will not be modified and will still work with the official Xiaomi app.
 
-Some configuration options can be set via environment variables, see config.ini.dist for details.
+Some configuration options can be set via environment variables, see `config.ini.dist` for details.
 
 ## Execution
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ sudo hcitool lescan
 Interfacing your Mi Flora sensor with this program is harmless.
 The device will not be modified and will still work with the official Xiaomi app.
 
+Some configuration options can be set via environment variables, see config.ini.dist for details.
+
 ## Execution
 
 A first test run is as easy as:

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -2,8 +2,8 @@
 # Source: https://github.com/ThomDietrich/miflora-mqtt-daemon
 #
 # Uncomment and adapt all settings as needed.
-# Some settings can be configured by environment variables. If the variable is set, it takes
-# precedence over settings in this file
+# Some settings can be configured by environment variables.
+# If an env variable is set, it takes precedence over settings in this file
 
 [General]
 

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -2,6 +2,8 @@
 # Source: https://github.com/ThomDietrich/miflora-mqtt-daemon
 #
 # Uncomment and adapt all settings as needed.
+# Some settings can be configured by environment variables. If the variable is set, it takes
+# precedence over settings in this file
 
 [General]
 
@@ -37,9 +39,11 @@
 [MQTT]
 
 # The hostname or IP address of the MQTT broker to connect to (Default: localhost)
+# Also read from the MQTT_HOSTNAME environment variable
 #hostname = localhost
 
 # The TCP port the MQTT broker is listening on (Default: 1883)
+# Also read from the MQTT_PORT environment variable
 #port = 1883
 
 # Maximum period in seconds between ping messages to the broker. (Default: 60)
@@ -57,6 +61,7 @@
 #homie_device_id = miflora-mqtt-daemon
 
 # The MQTT broker authentification credentials (Default: no authentication)
+# Will also read from MQTT_USERNAME and MQTT_PASSWORD environment variables
 #username = user
 #password = pwd123
 

--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -5,6 +5,7 @@ import sys
 import re
 import json
 import os.path
+import os
 import argparse
 from time import time, sleep, localtime, strftime
 from collections import OrderedDict
@@ -180,11 +181,14 @@ if reporting_mode in ['mqtt-json', 'mqtt-homie', 'mqtt-smarthome', 'homeassistan
             tls_version=ssl.PROTOCOL_SSLv23
         )
 
-    if config['MQTT'].get('username'):
-        mqtt_client.username_pw_set(config['MQTT'].get('username'), config['MQTT'].get('password', None))
+    mqtt_username = os.environ.get("MQTT_USERNAME", config['MQTT'].get('username'))
+    mqtt_password = os.environ.get("MQTT_PASSWORD", config['MQTT'].get('password', None))
+
+    if mqtt_username:
+        mqtt_client.username_pw_set(mqtt_username, mqtt_password)
     try:
-        mqtt_client.connect(config['MQTT'].get('hostname', 'localhost'),
-                            port=config['MQTT'].getint('port', 1883),
+        mqtt_client.connect(os.environ.get('MQTT_HOSTNAME', config['MQTT'].get('hostname', 'localhost')),
+                            port=int(os.environ.get('MQTT_PORT', config['MQTT'].get('port', '1883'))),
                             keepalive=config['MQTT'].getint('keepalive', 60))
     except:
         print_line('MQTT connection error. Please check your settings in the configuration file "config.ini"', error=True, sd_notify=True)


### PR DESCRIPTION
I put this change together a while ago, but forgot to open an MR.

This adds support for reading the MQTT username and password from environment variables. This is useful when deploying the Docker image