### PR TITLE
Set state_class to support HA long term statistics

### DIFF
--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -24,11 +24,11 @@ project_name = 'Xiaomi Mi Flora Plant Sensor MQTT Client/Daemon'
 project_url = 'https://github.com/ThomDietrich/miflora-mqtt-daemon'
 
 parameters = OrderedDict([
-    (MI_LIGHT, dict(name="LightIntensity", name_pretty='Sunlight Intensity', typeformat='%d', unit='lux', device_class="illuminance")),
-    (MI_TEMPERATURE, dict(name="AirTemperature", name_pretty='Air Temperature', typeformat='%.1f', unit='°C', device_class="temperature")),
-    (MI_MOISTURE, dict(name="SoilMoisture", name_pretty='Soil Moisture', typeformat='%d', unit='%', device_class="humidity")),
-    (MI_CONDUCTIVITY, dict(name="SoilConductivity", name_pretty='Soil Conductivity/Fertility', typeformat='%d', unit='µS/cm')),
-    (MI_BATTERY, dict(name="Battery", name_pretty='Sensor Battery Level', typeformat='%d', unit='%', device_class="battery"))
+    (MI_LIGHT, dict(name="LightIntensity", name_pretty='Sunlight Intensity', typeformat='%d', unit='lux', device_class="illuminance", state_class="measurement")),
+    (MI_TEMPERATURE, dict(name="AirTemperature", name_pretty='Air Temperature', typeformat='%.1f', unit='°C', device_class="temperature", state_class="measurement")),
+    (MI_MOISTURE, dict(name="SoilMoisture", name_pretty='Soil Moisture', typeformat='%d', unit='%', device_class="humidity", state_class="measurement")),
+    (MI_CONDUCTIVITY, dict(name="SoilConductivity", name_pretty='Soil Conductivity/Fertility', typeformat='%d', unit='µS/cm', state_class="measurement")),
+    (MI_BATTERY, dict(name="Battery", name_pretty='Sensor Battery Level', typeformat='%d', unit='%', device_class="battery", state_class="measurement"))
 ])
 
 if False:
@@ -335,6 +335,8 @@ elif reporting_mode == 'homeassistant-mqtt':
             payload['unit_of_measurement'] = params['unit']
             if 'device_class' in params:
                 payload['device_class'] = params['device_class']
+            if 'state_class' in params:
+                payload['state_class'] = params['state_class']
             payload['state_topic'] = state_topic
             payload['value_template'] = "{{{{ value_json.{} }}}}".format(sensor)
             payload['device'] = {


### PR DESCRIPTION
By setting the `state_class="measurement"` in accordance with
 https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics
 we can leverage the long term statistics of Home Assistant.

Here is an example where I have configured three Xiamo Mi Flora devices and plotting the temperature over time.
![image](https://user-images.githubusercontent.com/8560367/184716741-d9416757-e042-4b8c-9a73-e5863cf3c860.png)
Before making the change in this change I was not able to pick those entities, due to the missing `state_class`.