### PR TITLE
home-assistant: Choose an "expire_after" value based on the configured "period" value

### DIFF
--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -347,7 +347,7 @@ elif reporting_mode == 'homeassistant-mqtt':
                     'model' : 'MiFlora Plant Sensor (HHCCJCY01)',
                     'sw_version': flora['firmware']
             }
-            payload['expire_after'] = '3600'
+            payload['expire_after'] = str(sleep_period + 60)
             mqtt_client.publish(discovery_topic, json.dumps(payload), 1, True)
 elif reporting_mode == 'gladys-mqtt':
     print_line('Announcing Mi Flora devices to MQTT broker for auto-discovery ...')

--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -347,7 +347,7 @@ elif reporting_mode == 'homeassistant-mqtt':
                     'model' : 'MiFlora Plant Sensor (HHCCJCY01)',
                     'sw_version': flora['firmware']
             }
-            payload['expire_after'] = str(sleep_period + 60)
+            payload['expire_after'] = str(int(sleep_period * 1.5))
             mqtt_client.publish(discovery_topic, json.dumps(payload), 1, True)
 elif reporting_mode == 'gladys-mqtt':
     print_line('Announcing Mi Flora devices to MQTT broker for auto-discovery ...')


### PR DESCRIPTION
I use this daemon for my MiFlora sensors with Home Assistant via Mosquitto broker.

My sensors updates every 24 hours. As it is currently, a fixed value of `3600` for `expire_after` (added in #138) made my sensors appear as "Unavailable" after 3600 seconds.

This is why I think it makes the most sense to use a value derived from the `period` of updates as configured in the daemon. Because a sensor can only be considered unavailable if there were no updates when there was supposed to be one.