### PR TITLE
Added mode 'mqtt-pure'

### DIFF
--- a/config.ini.dist
+++ b/config.ini.dist
@@ -11,6 +11,7 @@
 # Currently supported:
 #
 #           mqtt-json - Publish to an MQTT broker in a proprietary json format (Default)
+#           mqtt-pure - Nothin fancy, just the bare information
 #          mqtt-homie - Publish to an MQTT broker following the Homie MQTT convention
 #                       (https://github.com/marvinroger/homie)
 #      mqtt-smarthome - Publish to an MQTT broker following the mqtt-smarthome proposal
@@ -53,7 +54,7 @@
 
 # The MQTT base topic to publish all Mi Flora sensor data topics under.
 # Default depends on the configured reporting_method
-#base_topic = miflora                   # Default for: mqtt-json, mqtt-smarthome, homeassistant-mqtt
+#base_topic = miflora                   # Default for: mqtt-json, mqtt-pure, mqtt-smarthome, homeassistant-mqtt
 #base_topic = homie                     # Default for: mqtt-homie
 #base_topic = gladys/master/device      # Default for: gladys-mqtt
 #base_topic = v1/devices/me/telemetry   # Default for: thingsboard-json


### PR DESCRIPTION
I added a mode to just publish the pure sensor data to MQTT.
Paths
  {base_topic}/{flora_name.lower}/light
  {base_topic}/{flora_name.lower}/temperature
  {base_topic}/{flora_name.lower}/moisture
  {base_topic}/{flora_name.lower}/conductivity
  {base_topic}/{flora_name.lower}/battery
Nothing fancy, just the information. ^^