### PR TITLE
Fix for HA 2023.8 and up

### DIFF
--- a/miflora-mqtt-daemon.py
+++ b/miflora-mqtt-daemon.py
@@ -330,7 +330,7 @@ elif reporting_mode == 'homeassistant-mqtt':
         for [sensor, params] in parameters.items():
             discovery_topic = 'homeassistant/sensor/{}/{}/config'.format(flora_name.lower(), sensor)
             payload = OrderedDict()
-            payload['name'] = "{} {}".format(flora_name, sensor.title())
+            payload['name'] = "{}".format(sensor.title())
             payload['unique_id'] = "{}-{}".format(flora['mac'].lower().replace(":", ""), sensor)
             payload['unit_of_measurement'] = params['unit']
             if 'device_class' in params:


### PR DESCRIPTION
The device name should not be pre-pended in the entity names anymore. This PR fixes that.

https://developers.home-assistant.io/blog/2023-057-21-change-naming-mqtt-entities/